### PR TITLE
FIX: Correctly handle the $current_url event prop

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,37 +2,26 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/index.test.ts
+++ b/index.test.ts
@@ -4,12 +4,12 @@ import { processEvent } from "./index";
 /**
  * Given a url, construct a page view event.
  *
- * @param current_url The current url of the page view
+ * @param $current_url The current url of the page view
  * @returns A new PostHog page view event
  */
-function buildPageViewEvent(current_url: string): PluginEvent {
+function buildPageViewEvent($current_url: string): PluginEvent {
   const event: PluginEvent = {
-    properties: { current_url },
+    properties: { $current_url },
     distinct_id: "distinct_id",
     ip: "1.2.3.4",
     site_url: "test.com",
@@ -47,7 +47,7 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/test"
     );
   });
@@ -59,7 +59,7 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/whatareyouthinking"
     );
   });
@@ -71,7 +71,7 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/this_is_a_test"
     );
   });
@@ -81,7 +81,7 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/"
     );
   });
@@ -93,7 +93,7 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/this_is_a_test#id_anchor"
     );
   });
@@ -105,22 +105,22 @@ describe("processEvent", () => {
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
-    expect(processedEvent?.properties?.current_url).toEqual(
+    expect(processedEvent?.properties?.$current_url).toEqual(
       "http://www.google.com/this_is_a_test_with_trailing_slash#id_anchor"
     );
   });
 
-  it("shouldn't modify events that don't have a current_url set", () => {
+  it("shouldn't modify events that don't have a $current_url set", () => {
     const sourceEvent = buildEventWithoutCurrentUrl();
 
     const processedEvent = processEvent(sourceEvent, getMeta());
 
     expect(processedEvent).toEqual(sourceEvent);
     expect(processedEvent?.properties).toEqual(sourceEvent.properties);
-    expect(processedEvent?.properties?.current_url).toBeUndefined();
+    expect(processedEvent?.properties?.$current_url).toBeUndefined();
   });
 
-  it("should raise an error if the current_url is an invalid url", () => {
+  it("should raise an error if the $current_url is an invalid url", () => {
     const sourceEvent = buildPageViewEvent("invalid url");
 
     expect(() => processEvent(sourceEvent, getMeta())).toThrowError(

--- a/index.ts
+++ b/index.ts
@@ -15,10 +15,10 @@ export function processEvent(
   event: PluginEvent,
   meta: PluginMeta<PluginInput>
 ) {
-  const current_url = event?.properties?.current_url;
-  if (event?.properties && current_url) {
-    const normalized_url = normalizeUrl(current_url);
-    event.properties.current_url = normalized_url;
+  const $current_url = event?.properties?.$current_url;
+  if (event?.properties && $current_url) {
+    const normalized_url = normalizeUrl($current_url);
+    event.properties.$current_url = normalized_url;
 
     console.debug(`normalized_url: ${normalized_url}`);
   }


### PR DESCRIPTION
Previously, the `$current_url` was misnamed in this app as `current_url`. This fixes that so that urls are normalized properly.

# Changes
* Rename `current_url` to `$current_url`
* Add issue templates.