### PR TITLE
Log the unnormalized url for debugging

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -127,4 +127,17 @@ describe("processEvent", () => {
       `Unable to normalize invalid URL: "invalid url"`
     );
   });
+
+  it("should log the normalized_url for debugging", () => {
+    const consoleSpy = jest.spyOn(console, "debug");
+
+    const sourceEvent = buildPageViewEvent(
+      "http://www.GoOGle.com/WhatAreYouThinking"
+    );
+    processEvent(sourceEvent, getMeta());
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "normalized_url: http://www.google.com/whatareyouthinking"
+    );
+  });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -137,7 +137,7 @@ describe("processEvent", () => {
     processEvent(sourceEvent, getMeta());
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      "normalized_url: http://www.google.com/whatareyouthinking"
+      'event.$current_url: "http://www.GoOGle.com/WhatAreYouThinking" normalized to "http://www.google.com/whatareyouthinking"'
     );
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,9 @@ export function processEvent(
     const normalized_url = normalizeUrl($current_url);
     event.properties.$current_url = normalized_url;
 
-    console.debug(`normalized_url: ${normalized_url}`);
+    console.debug(
+      `event.$current_url: "${$current_url}" normalized to "${normalized_url}"`
+    );
   }
 
   return event;


### PR DESCRIPTION
I'm seeing some urls that aren't getting the trailing slash stripped which is breaking analytics.